### PR TITLE
Allow ARPA from lmplz, error checking in shell script

### DIFF
--- a/include/arpafile.h
+++ b/include/arpafile.h
@@ -6,6 +6,7 @@
 #include<cstring>
 
 #include<fstream>
+#include<stdexcept>
 #include<vector>
 
 #include "logger.h"
@@ -90,11 +91,10 @@ namespace DALM {
 				std::vector<size_t> ngramnums;
 				std::string line;
 
-				std::getline(arpastream, line); // skip blank line.
-				std::getline(arpastream, line); // skip \data\ line.
+				while (std::getline(arpastream, line) && line.empty()) {} // skip blank line.
 				if(line != "\\data\\"){
 					logger << "ARPA file format error. abort." << Logger::endc;
-					throw "error.";
+					throw std::runtime_error("error.");
 				}
 
 				std::getline(arpastream, line);

--- a/scripts/build_dalm.sh
+++ b/scripts/build_dalm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 if [ $# -ne 3 ]; then
 	echo "Usage: $0 arpa-file division-number output-dir"
 	exit 1


### PR DESCRIPTION
lmplz doesn't put a line before \data\.  That caused the dumper to fail.  But the shell script kept on going due to a missing set -e.  Parsing the empty file then left the size variable uninitialized (since you don't check the result of fread) and DALM went into a very long loop counting to an uninitialized value.   